### PR TITLE
✨ feat: XHR 패치 기능을 추가하여 HTTP 요청/응답을 devtools에 기록한다

### DIFF
--- a/src/devtools/index.tsx
+++ b/src/devtools/index.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { patchFetch, unPatchFetch } from '@/entities/http';
+import { patchFetch, patchXHR, unPatchFetch, unPatchXHR } from '@/entities/http';
 import { patchSocketIO } from '@/entities/websocket';
 import { useRecordingStore } from '@/features/record';
 import { OpenDevtoolsButton, useUiModeStore } from '@/features/switch-ui-mode';
@@ -13,9 +13,11 @@ const ApiRecorderDevtools = () => {
   useEffect(() => {
     patchFetch({ options, pushEvents });
     patchSocketIO({ pushEvents });
+    patchXHR({ options, pushEvents });
 
     return () => {
       unPatchFetch();
+      unPatchXHR();
     };
   }, [options, pushEvents]);
 

--- a/src/entities/http/index.ts
+++ b/src/entities/http/index.ts
@@ -1,1 +1,2 @@
 export * from './patch-fetch';
+export * from './patch-xhr';

--- a/src/entities/http/patch-fetch.ts
+++ b/src/entities/http/patch-fetch.ts
@@ -1,4 +1,5 @@
 import type { THttpRequestEvent, THttpResponseEvent, TRecEvent, TRecordingOptions } from '@/shared/api';
+import { cloneBody } from './utils';
 
 let originalFetch: typeof window.fetch | null = null;
 
@@ -113,26 +114,6 @@ const unPatchFetch = () => {
 };
 
 export { patchFetch, unPatchFetch };
-
-const cloneBody = async (body: BodyInit): Promise<unknown> => {
-  if (typeof body === 'string') {
-    return body;
-  }
-  if (body instanceof FormData) {
-    const result: Record<string, unknown> = {};
-    body.forEach((value, key) => {
-      result[key] = value instanceof File ? `[File: ${value.name}]` : value;
-    });
-    return result;
-  }
-  if (body instanceof URLSearchParams) {
-    return Object.fromEntries(body.entries());
-  }
-  if (body instanceof ArrayBuffer || body instanceof Uint8Array) {
-    return `[Binary data: ${body.byteLength} bytes]`;
-  }
-  return '[Unknown body type]';
-};
 
 type TArgs = {
   options: TRecordingOptions;

--- a/src/entities/http/patch-xhr.ts
+++ b/src/entities/http/patch-xhr.ts
@@ -1,0 +1,111 @@
+import type { THttpRequestEvent, THttpResponseEvent, TRecEvent, TRecordingOptions } from '@/shared/api';
+import { cloneBody } from './utils';
+
+let originalXHR: typeof window.XMLHttpRequest | null = null;
+
+const patchXHR = ({ options, pushEvents }: TArgs) => {
+  if (originalXHR) return;
+  originalXHR = window.XMLHttpRequest;
+
+  class PatchedXMLHttpRequest extends originalXHR {
+    private _requestId = Math.random().toString(36).slice(2);
+    private _startTime = 0;
+    private _url = '';
+    private _method = 'GET';
+
+    private _requestHeaders: Record<string, string> = {};
+
+    open(method: string, url: string, async = true, user?: string, password?: string) {
+      this._method = method;
+      this._url = url;
+      super.open(method, url, async, user, password);
+    }
+
+    setRequestHeader(header: string, value: string) {
+      this._requestHeaders[header] = value;
+      super.setRequestHeader(header, value);
+    }
+
+    async send(body?: Document | XMLHttpRequestBodyInit | null) {
+      if (options.ignore(this._url)) {
+        return super.send(body);
+      }
+
+      this._startTime = Date.now();
+
+      const requestEvent: THttpRequestEvent = {
+        id: `${this._requestId}-req`,
+        sender: 'client',
+        protocol: 'http',
+        method: this._method,
+        url: this._url,
+        headers: options.includeHeaders ? this._requestHeaders : undefined,
+        body: body && body instanceof Document === false ? await cloneBody(body as BodyInit) : undefined,
+        requestId: this._requestId,
+      };
+
+      pushEvents(requestEvent);
+
+      this.addEventListener('loadend', () => {
+        const endTime = Date.now();
+
+        const responseHeaders = parseResponseHeaders(this.getAllResponseHeaders());
+
+        let responseBody: unknown;
+        try {
+          const contentType = this.getResponseHeader('content-type') || '';
+          if (contentType.includes('application/json')) {
+            responseBody = JSON.parse(this.responseText);
+          } else if (contentType.includes('text/')) {
+            responseBody = this.responseText;
+          } else {
+            responseBody = `[Binary response]`;
+          }
+        } catch {}
+
+        const responseEvent: THttpResponseEvent = {
+          id: `${this._requestId}-res`,
+          sender: 'server',
+          protocol: 'http',
+          status: this.status,
+          statusText: this.statusText,
+          headers: options.includeHeaders ? responseHeaders : undefined,
+          body: responseBody,
+          requestId: this._requestId,
+          delayMs: endTime - this._startTime,
+        };
+
+        pushEvents(responseEvent);
+      });
+
+      super.send(body);
+    }
+  }
+
+  window.XMLHttpRequest = PatchedXMLHttpRequest as typeof XMLHttpRequest;
+};
+
+const unPatchXHR = () => {
+  if (originalXHR) {
+    window.XMLHttpRequest = originalXHR;
+    originalXHR = null;
+  }
+};
+
+export { patchXHR, unPatchXHR };
+
+const parseResponseHeaders = (rawHeaders: string): Record<string, string> => {
+  const headers: Record<string, string> = {};
+  rawHeaders.split('\r\n').forEach(line => {
+    const [key, ...rest] = line.split(': ');
+    if (key && rest.length > 0) {
+      headers[key.trim()] = rest.join(': ').trim();
+    }
+  });
+  return headers;
+};
+
+type TArgs = {
+  options: TRecordingOptions;
+  pushEvents: (e: TRecEvent) => void;
+};

--- a/src/entities/http/utils.ts
+++ b/src/entities/http/utils.ts
@@ -1,0 +1,19 @@
+export const cloneBody = async (body: BodyInit): Promise<unknown> => {
+  if (typeof body === 'string') {
+    return body;
+  }
+  if (body instanceof FormData) {
+    const result: Record<string, unknown> = {};
+    body.forEach((value, key) => {
+      result[key] = value instanceof File ? `[File: ${value.name}]` : value;
+    });
+    return result;
+  }
+  if (body instanceof URLSearchParams) {
+    return Object.fromEntries(body.entries());
+  }
+  if (body instanceof ArrayBuffer || body instanceof Uint8Array) {
+    return `[Binary data: ${body.byteLength} bytes]`;
+  }
+  return '[Unknown body type]';
+};


### PR DESCRIPTION
## ✨ 작업 배경 [#](#background) <span id="background"></span>

내부적으로 `XMLHttpRequest`를 사용하는 라이브러리(예: `Axios`)를 지원하기 위해,
fetch 외에도 `XHR` 요청을 캡처할 수 있도록 패치 기능을 추가했습니다.

## 💻 작업 내용 [#](#work_detail) <span id="work_detail"></span>

- xhr 패치 기능 추가 

## 🏃 기능 동작 시연 [#](#prove) <span id="prove"></span>
- axios로 테스트 
![화면 기록 2025-08-06 오후 2 56 29](https://github.com/user-attachments/assets/522e0773-391e-4139-8484-66336761a29a)


