### PR TITLE
✨ feat: 소켓 서버의 connect error를 기록한다

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ node_modules/
 !.yarn/sdks/**              
 !.pnp.cjs                   
 !.pnp.loader.mjs     
+
+
+package.tgz

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "exports": {
     ".": {
       "types": "./dist/main.d.ts",
-      "import": "./dist/api-recorder.es.js"
+      "import": "./dist/api-recorder.es.js",
+      "require": "./dist/api-recorder.es.js"
     }
   },
   "files": [

--- a/src/devtools/ui/maximized-view.tsx
+++ b/src/devtools/ui/maximized-view.tsx
@@ -25,24 +25,27 @@ const MaximizedView = () => {
   const [selectedRequestId, setSelectedRequestId] = useState<string | null>(null);
   const { groupedEvents } = useRecordingStore();
 
-  const tabs = [
-    { label: 'All', value: 'all', count: groupedEvents.length },
-    {
-      label: 'HTTP',
-      value: 'http',
-      count: groupedEvents.filter(g => g.type === 'http-rest').length,
-    },
-    {
-      label: 'Stream',
-      value: 'stream',
-      count: groupedEvents.filter(g => g.type === 'http-stream').length,
-    },
-    {
-      label: 'Socket.io',
-      value: 'socketio',
-      count: groupedEvents.filter(g => g.type === 'socketio').length,
-    },
-  ];
+  const tabs = useMemo(
+    () => [
+      { label: 'All', value: 'all', count: groupedEvents.length },
+      {
+        label: 'HTTP',
+        value: 'http',
+        count: groupedEvents.filter(g => g.type === 'http-rest').length,
+      },
+      {
+        label: 'Stream',
+        value: 'stream',
+        count: groupedEvents.filter(g => g.type === 'http-stream').length,
+      },
+      {
+        label: 'Socket.io',
+        value: 'socketio',
+        count: groupedEvents.filter(g => g.type === 'socketio').length,
+      },
+    ],
+    [groupedEvents],
+  );
 
   const filtered = useMemo(() => {
     return groupedEvents.filter(group => {
@@ -63,7 +66,7 @@ const MaximizedView = () => {
     [groupedEvents, selectedRequestId],
   );
 
-  const renderTabContent = () => {
+  const renderTabContent = useMemo(() => {
     if (selectedTab === 'socketio' && !isSocketIOAvailable()) {
       return <SocketIOInstallPrompt />;
     }
@@ -81,7 +84,7 @@ const MaximizedView = () => {
         {selectedRequestId && selectedGroup && <EventDetail group={selectedGroup} />}
       </div>
     );
-  };
+  }, [selectedTab, selectedRequestId, filtered, selectedGroup]);
 
   return (
     <ResizableFrame>
@@ -119,7 +122,7 @@ const MaximizedView = () => {
         </div>
       </div>
 
-      <div className={mainContentStyle}>{renderTabContent()}</div>
+      <div className={mainContentStyle}>{renderTabContent}</div>
     </ResizableFrame>
   );
 };

--- a/src/entities/record/types.ts
+++ b/src/entities/record/types.ts
@@ -60,6 +60,11 @@ export type TSocketIOGroup = {
     url: string;
     namespace?: string;
     timestamp: number;
+    reject?: {
+      message: string;
+      afterMs?: number;
+      code?: string;
+    };
   };
   /** 해당 연결의 모든 메시지들 */
   messages: TMessage[];

--- a/src/shared/api/events.ts
+++ b/src/shared/api/events.ts
@@ -67,6 +67,15 @@ export type TSocketIOEvent = TBaseEvent & {
   data: unknown[];
   /** 바이너리 여부 표식(있으면 UI에서 길이/hex 등으로 표시) */
   isBinary?: boolean;
+  /** 연결 오류 정보 (connect_error 이벤트일 때만 사용) */
+  reject?: {
+    /** 오류 메시지 */
+    message: string;
+    /** 연결 시도 후 경과 시간(ms) */
+    afterMs?: number;
+    /** 오류 코드 */
+    code?: string;
+  };
 };
 
 export type TRecEvent = THttpRequestEvent | THttpResponseEvent | THttpStreamEvent | TSocketIOEvent;

--- a/src/widgets/detail-view/ui/event-detail.tsx
+++ b/src/widgets/detail-view/ui/event-detail.tsx
@@ -13,7 +13,7 @@ const EventDetail = ({ group }: TProps) => {
   }
 
   if (group.type === 'socketio') {
-    return <SocketIODetail events={group.messages} selectedRequestId={group.requestId} />;
+    return <SocketIODetail events={group.messages} connection={group.connection} selectedRequestId={group.requestId} />;
   }
 
   return null;

--- a/src/widgets/detail-view/ui/socketio-detail.tsx
+++ b/src/widgets/detail-view/ui/socketio-detail.tsx
@@ -15,7 +15,7 @@ import {
   sectionStyle,
 } from './styles.css';
 
-const SocketIODetail = ({ events, selectedRequestId }: TProps) => {
+const SocketIODetail = ({ events, connection, selectedRequestId }: TProps) => {
   if (events.length === 0) {
     return (
       <div className={detailContainerStyle} style={{ minHeight: '200px' }}>
@@ -33,6 +33,26 @@ const SocketIODetail = ({ events, selectedRequestId }: TProps) => {
               <code>0</code>
             </div>
           </div>
+          {connection.reject && (
+            <div
+              style={{
+                marginTop: 12,
+                padding: 8,
+                backgroundColor: '#fee2e2',
+                border: '1px solid #fecaca',
+                borderRadius: 4,
+                color: '#dc2626',
+              }}
+            >
+              <strong>Connection Error:</strong> {connection.reject.message}
+              {connection.reject.code && (
+                <div style={{ fontSize: 12, opacity: 0.8 }}>Code: {connection.reject.code}</div>
+              )}
+              {connection.reject.afterMs && (
+                <div style={{ fontSize: 12, opacity: 0.8 }}>After: {connection.reject.afterMs}ms</div>
+              )}
+            </div>
+          )}
         </div>
         <div className={dividerStyle} />
         <div className={sectionStyle}>
@@ -105,12 +125,22 @@ const SocketTimeline = ({ events }: { events: TMessage[] }) => {
 };
 
 const TimelineCard = ({ leftPill, title, time, payload }: TTimelineCardProps) => {
+  const isConnectError = title === 'connect_error';
+
   return (
-    <div style={{ padding: 8, border: '1px solid #1f2937', borderRadius: 6 }}>
+    <div
+      style={{
+        padding: 8,
+        border: '1px solid #1f2937',
+        borderRadius: 6,
+        backgroundColor: isConnectError ? '#fee2e2' : 'transparent',
+        borderColor: isConnectError ? '#dc2626' : '#1f2937',
+      }}
+    >
       <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
         <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
           {leftPill}
-          <strong>{title}</strong>
+          <strong style={{ color: isConnectError ? '#dc2626' : 'inherit' }}>{title}</strong>
           <span style={{ opacity: 0.6, fontSize: 12 }}>{time}</span>
         </div>
       </div>
@@ -123,6 +153,16 @@ const TimelineCard = ({ leftPill, title, time, payload }: TTimelineCardProps) =>
 
 type TProps = {
   events: TMessage[];
+  connection: {
+    url: string;
+    namespace?: string;
+    timestamp: number;
+    reject?: {
+      message: string;
+      afterMs?: number;
+      code?: string;
+    };
+  };
   selectedRequestId: string;
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -350,6 +350,9 @@ __metadata:
     react: ^18.0.0 || ^19.0.0
     react-dom: ^18.0.0 || ^19.0.0
     socket.io-client: ^4.8.2
+  peerDependenciesMeta:
+    socket.io-client:
+      optional: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## ✨ 작업 배경 [#](#background) <span id="background"></span>

소켓 서버에서 handshake를 거절하여 connect error를 내려줄 때, 이를 재현하기 위해 이벤트로 기록한 작업입니다. 

✔️ Related issues #21 

- Close #21 

## 💻 작업 내용 [#](#work_detail) <span id="work_detail"></span>

- socket patch할 때 connect_error 이벤트를 push
- connection에 reject 필드 추가 
- ui에 추가


## 🏃 기능 동작 시연 [#](#prove) <span id="prove"></span>

export했을 때 

```json
 {
    "requestId": "aw09n6icwae",
    "type": "socketio",
    "connection": {
      "url": "http://localhost:3000",
      "timestamp": 1755567315643,
      "reject": {
        "message": "SocketErrorType.INVALID_PARAM",
        "afterMs": 1000,
        "code": "Error"
      }
    },
    "messages": []
  }
```

<img width="3000" height="910" alt="image" src="https://github.com/user-attachments/assets/c98cb88c-f600-4f77-9513-33cf0562a404" />

