### PR TITLE
✨ 새로고침해도 녹화 데이터가 유지되도록 한다.

### DIFF
--- a/src/entities/record/model/recording-store.ts
+++ b/src/entities/record/model/recording-store.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import { persist } from 'zustand/middleware';
+import { persist, createJSONStorage } from 'zustand/middleware';
 
 type TRecordingState = {
   isRecording: boolean;
@@ -24,6 +24,7 @@ const useRecordingStore = create<TRecordingState>()(
     {
       name: 'api-recorder:recording',
       skipHydration: false,
+      storage: createJSONStorage(() => sessionStorage),
     },
   ),
 );


### PR DESCRIPTION
## ✨ 작업 배경 [#](#background) <span id="background"></span>

<!-- 작업하게 된 이유/배경 설명 -->

여러번 새로고침하는 경우에 대한 api 데이터를 녹화하는 경우를 대응하기 위해 녹화된 데이터를 세션스토리지에 유지하도록 추가한 작업입니다.

<!-- ⚠️  버그/오류의 경우, 문제를 정의 -->
<!-- 🆕  새로운 스펙의 경우, 스펙 설명 -->

<!-- 관련 이슈 링크 -->

✔️ Related issues #

<!-- Merge시 자동으로 close 하고 싶은 이슈가 있다면 -->
<!-- - Resolve # -->
<!-- - Fix # -->
<!-- - Close # -->

## 💻 작업 내용 [#](#work_detail) <span id="work_detail"></span>

<!-- 작업 내용 설명 -->

### 🔑 Key changes - 주요 변화
- zustand persist를 사용해서 세션스토리지에 녹화 데이터가 저장되도록 추가했습니다.


## 🏃 기능 동작 시연 [#](#prove) <span id="prove"></span>

<!-- 이미지, 영상, 시나리오 첨부 -->

## 💬 코멘트 [#](#comments) <span id="comments"></span>

<!-- 리뷰어에게 전달하고 싶은 사항, 리뷰 시 확인해야 하는 사항 등-->
